### PR TITLE
Add utility methods to retrieve the absolute path of the data dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,35 @@ This replaces the `utils.js` included in the ioBroker template adapter.
     ```
 3. Create an adapter instance as usual:
     ```js
+    // old style
     const adapter = utils.adapter(/* options */);
+    // new style (classes). See https://github.com/ioBroker/ioBroker.template/ for a more detailed usage
+    class MyAdapter extends utils.Adapter {...}
     ```
+
+## Utility methods
+
+Compared to the old `utils.js`, some utility methods were added.
+
+### `getAbsoluteDefaultDataDir`
+
+```js
+const dataDir = utils.getAbsoluteDefaultDataDir();
+```
+
+This returns the absolute path of the data directory for the current host. On linux, this is usually `/opt/iobroker/iobroker-data`
+
+### `getAbsoluteInstanceDataDir`
+
+```js
+// old style
+const instanceDataDir = utils.getAbsoluteInstanceDataDir(adapter);
+// new style (classes)
+const instanceDataDir = utils.getAbsoluteInstanceDataDir(this);
+```
+
+Returns the absolute path of the data directory for the current adapter instance.
+On linux, this is usually `/opt/iobroker/iobroker-data/<adapterName>.<instanceNr>`
 
 ## Tips while working on this module
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,22 @@ const instanceDataDir = utils.getAbsoluteInstanceDataDir(this);
 Returns the absolute path of the data directory for the current adapter instance.
 On linux, this is usually `/opt/iobroker/iobroker-data/<adapterName>.<instanceNr>`
 
+## Automatic backup of data files
+
+ioBroker has the ability to include files written by adapters in its backups. To enable that, you need to add the following to `io-package.json`:
+
+```json
+{
+	// ...
+	"common": {
+		// ...
+		"dataFolder": "path/where/your/files/are"
+	}
+}
+```
+
+This path is relative to the path returned by `getAbsoluteDefaultDataDir()`. The placeholder `%INSTANCE%` is automatically replaced by the instance number of each adapter, for example `"dataFolder": "my-adapter.%INSTANCE%"`.
+
 ## Tips while working on this module
 
 -   `npm run build` creates a clean rebuild of the module. This is done automatically before every build

--- a/build/index.d.ts
+++ b/build/index.d.ts
@@ -1,11 +1,11 @@
 /// <reference types="iobroker" />
 export * from "./utils";
 /**
- * Returns the absolute path of the data directory for the current host. On linux, this is usually /opt/iobroker/iobroker-data.
+ * Returns the absolute path of the data directory for the current host. On linux, this is usually `/opt/iobroker/iobroker-data`.
  */
 export declare function getAbsoluteDefaultDataDir(): string;
 /**
  * Returns the absolute path of the data directory for the current adapter instance.
- * On linux, this is usually /opt/iobroker/iobroker-data/<adapterName>.<instanceNr>
+ * On linux, this is usually `/opt/iobroker/iobroker-data/<adapterName>.<instanceNr>`
  */
 export declare function getAbsoluteInstanceDataDir(adapterObject: ioBroker.Adapter): string;

--- a/build/index.d.ts
+++ b/build/index.d.ts
@@ -1,2 +1,11 @@
-import * as utils from "./utils";
-export = utils;
+/// <reference types="iobroker" />
+export * from "./utils";
+/**
+ * Returns the absolute path of the data directory for the current host. On linux, this is usually /opt/iobroker/iobroker-data.
+ */
+export declare function getAbsoluteDefaultDataDir(): string;
+/**
+ * Returns the absolute path of the data directory for the current adapter instance.
+ * On linux, this is usually /opt/iobroker/iobroker-data/<adapterName>.<instanceNr>
+ */
+export declare function getAbsoluteInstanceDataDir(adapterObject: ioBroker.Adapter): string;

--- a/build/index.js
+++ b/build/index.js
@@ -11,7 +11,7 @@ const utils = require("./utils");
 // Export some additional utility methods
 const controllerTools = require(path.join(utils.controllerDir, "lib/tools"));
 /**
- * Returns the absolute path of the data directory for the current host. On linux, this is usually /opt/iobroker/iobroker-data.
+ * Returns the absolute path of the data directory for the current host. On linux, this is usually `/opt/iobroker/iobroker-data`.
  */
 function getAbsoluteDefaultDataDir() {
     return path.join(utils.controllerDir, controllerTools.getDefaultDataDir());
@@ -19,7 +19,7 @@ function getAbsoluteDefaultDataDir() {
 exports.getAbsoluteDefaultDataDir = getAbsoluteDefaultDataDir;
 /**
  * Returns the absolute path of the data directory for the current adapter instance.
- * On linux, this is usually /opt/iobroker/iobroker-data/<adapterName>.<instanceNr>
+ * On linux, this is usually `/opt/iobroker/iobroker-data/<adapterName>.<instanceNr>`
  */
 function getAbsoluteInstanceDataDir(adapterObject) {
     return path.join(getAbsoluteDefaultDataDir(), adapterObject.namespace);

--- a/build/index.js
+++ b/build/index.js
@@ -1,4 +1,28 @@
 "use strict";
+/* eslint-disable @typescript-eslint/no-var-requires */
+function __export(m) {
+    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+}
+Object.defineProperty(exports, "__esModule", { value: true });
+// Export all methods that used to be in utils.js
+__export(require("./utils"));
+const path = require("path");
 const utils = require("./utils");
-module.exports = utils;
+// Export some additional utility methods
+const controllerTools = require(path.join(utils.controllerDir, "lib/tools"));
+/**
+ * Returns the absolute path of the data directory for the current host. On linux, this is usually /opt/iobroker/iobroker-data.
+ */
+function getAbsoluteDefaultDataDir() {
+    return path.join(utils.controllerDir, controllerTools.getDefaultDataDir());
+}
+exports.getAbsoluteDefaultDataDir = getAbsoluteDefaultDataDir;
+/**
+ * Returns the absolute path of the data directory for the current adapter instance.
+ * On linux, this is usually /opt/iobroker/iobroker-data/<adapterName>.<instanceNr>
+ */
+function getAbsoluteInstanceDataDir(adapterObject) {
+    return path.join(getAbsoluteDefaultDataDir(), adapterObject.namespace);
+}
+exports.getAbsoluteInstanceDataDir = getAbsoluteInstanceDataDir;
 // TODO: Expose some system utilities here, e.g. for installing npm modules (GH#1)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@iobroker/adapter-core",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iobroker/adapter-core",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Core module to be used in ioBroker adapters. Acts as the bridge to js-controller.",
   "author": {
     "name": "AlCalzone",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,30 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+// Export all methods that used to be in utils.js
+export * from "./utils";
+
+import * as path from "path";
 import * as utils from "./utils";
-export = utils;
+
+// Export some additional utility methods
+
+const controllerTools = require(path.join(utils.controllerDir, "lib/tools"));
+
+/**
+ * Returns the absolute path of the data directory for the current host. On linux, this is usually /opt/iobroker/iobroker-data.
+ */
+export function getAbsoluteDefaultDataDir(): string {
+	return path.join(utils.controllerDir, controllerTools.getDefaultDataDir());
+}
+
+/**
+ * Returns the absolute path of the data directory for the current adapter instance.
+ * On linux, this is usually /opt/iobroker/iobroker-data/<adapterName>.<instanceNr>
+ */
+export function getAbsoluteInstanceDataDir(
+	adapterObject: ioBroker.Adapter,
+): string {
+	return path.join(getAbsoluteDefaultDataDir(), adapterObject.namespace);
+}
 
 // TODO: Expose some system utilities here, e.g. for installing npm modules (GH#1)

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import * as utils from "./utils";
 const controllerTools = require(path.join(utils.controllerDir, "lib/tools"));
 
 /**
- * Returns the absolute path of the data directory for the current host. On linux, this is usually /opt/iobroker/iobroker-data.
+ * Returns the absolute path of the data directory for the current host. On linux, this is usually `/opt/iobroker/iobroker-data`.
  */
 export function getAbsoluteDefaultDataDir(): string {
 	return path.join(utils.controllerDir, controllerTools.getDefaultDataDir());
@@ -19,7 +19,7 @@ export function getAbsoluteDefaultDataDir(): string {
 
 /**
  * Returns the absolute path of the data directory for the current adapter instance.
- * On linux, this is usually /opt/iobroker/iobroker-data/<adapterName>.<instanceNr>
+ * On linux, this is usually `/opt/iobroker/iobroker-data/<adapterName>.<instanceNr>`
  */
 export function getAbsoluteInstanceDataDir(
 	adapterObject: ioBroker.Adapter,


### PR DESCRIPTION
This PR adds two utility methods to retrieve the absolute path of the data dir. The method included in JS-Controller uses relative paths, which can lead to undesired behavior while developing with npm-linked modules. `getAbsoluteInstanceDataDir` was added to have a tidy data directory (preferably separate subdirectories by instance).

### `getAbsoluteDefaultDataDir`

```js
const dataDir = utils.getAbsoluteDefaultDataDir();
```

This returns the absolute path of the data directory for the current host. On linux, this is usually `/opt/iobroker/iobroker-data`

### `getAbsoluteInstanceDataDir`

```js
// old style
const instanceDataDir = utils.getAbsoluteInstanceDataDir(adapter);
// new style (classes)
const instanceDataDir = utils.getAbsoluteInstanceDataDir(this);
```

Returns the absolute path of the data directory for the current adapter instance.
On linux, this is usually `/opt/iobroker/iobroker-data/<adapterName>.<instanceNr>`

