### PR TITLE
Remove the conditional typing for adapter.oObjects and .oStates

### DIFF
--- a/build/utils.d.ts
+++ b/build/utils.d.ts
@@ -3,30 +3,11 @@
 export declare const controllerDir: string;
 /** Reads the configuration file of JS-Controller */
 export declare function getConfig(): Record<string, any>;
-/**
- * This type is used to include and exclude the states and objects cache from the adaptert type definition depending on the creation options
- */
-export declare type AdapterInstance = Omit<ioBroker.Adapter, "oObjects" | "oStates">;
-declare type AdapterInstanceType<T extends ioBroker.AdapterOptions> = T extends {
-    objects: true;
-    states: true;
-} ? AdapterInstance & {
-    oObjects: Exclude<ioBroker.Adapter["oObjects"], undefined>;
-    oStates: Exclude<ioBroker.Adapter["oStates"], undefined>;
-} : T extends {
-    objects: true;
-} ? AdapterInstance & {
-    oObjects: Exclude<ioBroker.Adapter["oObjects"], undefined>;
-} : T extends {
-    states: true;
-} ? AdapterInstance & {
-    oStates: Exclude<ioBroker.Adapter["oStates"], undefined>;
-} : AdapterInstance;
 interface AdapterConstructor {
-    new (adapterName: string): AdapterInstance;
-    new <T extends ioBroker.AdapterOptions>(adapterOptions: T): AdapterInstanceType<T>;
-    (adapterName: string): AdapterInstance;
-    <T extends ioBroker.AdapterOptions>(adapterOptions: ioBroker.AdapterOptions): AdapterInstanceType<T>;
+    new (adapterName: string): ioBroker.Adapter;
+    new (adapterOptions: ioBroker.AdapterOptions): ioBroker.Adapter;
+    (adapterName: string): ioBroker.Adapter;
+    (adapterOptions: ioBroker.AdapterOptions): ioBroker.Adapter;
 }
 /** Creates a new adapter instance */
 export declare const adapter: AdapterConstructor;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -52,32 +52,30 @@ export function getConfig(): Record<string, any> {
  * This type is used to include and exclude the states and objects cache from the adaptert type definition depending on the creation options
  */
 // oObjects and oStates only exist if the corresponding options are set to true
-export type AdapterInstance = Omit<ioBroker.Adapter, "oObjects" | "oStates">;
-
 type AdapterInstanceType<T extends ioBroker.AdapterOptions> = T extends {
 	objects: true;
 	states: true;
 }
-	? AdapterInstance & {
+	? ioBroker.Adapter & {
 			oObjects: Exclude<ioBroker.Adapter["oObjects"], undefined>;
 			oStates: Exclude<ioBroker.Adapter["oStates"], undefined>;
 	  }
 	: T extends { objects: true }
-	? AdapterInstance & {
+	? Omit<ioBroker.Adapter, "oStates"> & {
 			oObjects: Exclude<ioBroker.Adapter["oObjects"], undefined>;
 	  }
 	: T extends { states: true }
-	? AdapterInstance & {
+	? Omit<ioBroker.Adapter, "oObjects"> & {
 			oStates: Exclude<ioBroker.Adapter["oStates"], undefined>;
 	  }
-	: AdapterInstance;
+	: Omit<ioBroker.Adapter, "oObjects" | "oStates">;
 
 interface AdapterConstructor {
-	new (adapterName: string): AdapterInstance;
+	new (adapterName: string): ioBroker.Adapter;
 	new <T extends ioBroker.AdapterOptions>(
 		adapterOptions: T,
 	): AdapterInstanceType<T>;
-	(adapterName: string): AdapterInstance;
+	(adapterName: string): ioBroker.Adapter;
 	<T extends ioBroker.AdapterOptions>(
 		adapterOptions: ioBroker.AdapterOptions,
 	): AdapterInstanceType<T>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -48,37 +48,11 @@ export function getConfig(): Record<string, any> {
 	);
 }
 
-/**
- * This type is used to include and exclude the states and objects cache from the adaptert type definition depending on the creation options
- */
-// oObjects and oStates only exist if the corresponding options are set to true
-type AdapterInstanceType<T extends ioBroker.AdapterOptions> = T extends {
-	objects: true;
-	states: true;
-}
-	? ioBroker.Adapter & {
-			oObjects: Exclude<ioBroker.Adapter["oObjects"], undefined>;
-			oStates: Exclude<ioBroker.Adapter["oStates"], undefined>;
-	  }
-	: T extends { objects: true }
-	? Omit<ioBroker.Adapter, "oStates"> & {
-			oObjects: Exclude<ioBroker.Adapter["oObjects"], undefined>;
-	  }
-	: T extends { states: true }
-	? Omit<ioBroker.Adapter, "oObjects"> & {
-			oStates: Exclude<ioBroker.Adapter["oStates"], undefined>;
-	  }
-	: Omit<ioBroker.Adapter, "oObjects" | "oStates">;
-
 interface AdapterConstructor {
 	new (adapterName: string): ioBroker.Adapter;
-	new <T extends ioBroker.AdapterOptions>(
-		adapterOptions: T,
-	): AdapterInstanceType<T>;
+	new (adapterOptions: ioBroker.AdapterOptions): ioBroker.Adapter;
 	(adapterName: string): ioBroker.Adapter;
-	<T extends ioBroker.AdapterOptions>(
-		adapterOptions: ioBroker.AdapterOptions,
-	): AdapterInstanceType<T>;
+	(adapterOptions: ioBroker.AdapterOptions): ioBroker.Adapter;
 }
 /** Creates a new adapter instance */
 // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/test/types/utils.ts
+++ b/test/types/utils.ts
@@ -13,4 +13,11 @@ const adapter5 = utils.adapter(options);
 const adapter6 = utils.Adapter(options);
 
 const adapter7 = new utils.adapter(options);
-const adapter8 = new utils.Adapter(options);
+const adapter8 = new utils.Adapter({ ...options, objects: true });
+
+class adapter9 extends utils.Adapter {
+	constructor() {
+		super({ name: "foo", objects: true });
+		this.oObjects;
+	}
+}


### PR DESCRIPTION
This made it impossible to use classes to write adapters. We can try again once the adapter.js is a real class.