### PR TITLE
Add correct types for conditional oStates/oObjects types

### DIFF
--- a/build/utils.d.ts
+++ b/build/utils.d.ts
@@ -3,11 +3,27 @@
 export declare const controllerDir: string;
 /** Reads the configuration file of JS-Controller */
 export declare function getConfig(): Record<string, any>;
+/**
+ * This type is used to include and exclude the states and objects cache from the adaptert type definition depending on the creation options
+ */
+export interface AdapterInstance<HasObjectsCache extends boolean | undefined = undefined, HasStatesCache extends boolean | undefined = undefined> extends Omit<ioBroker.Adapter, "oObjects" | "oStates"> {
+    oObjects: HasObjectsCache extends true ? Exclude<ioBroker.Adapter["oObjects"], undefined> : undefined;
+    oStates: HasStatesCache extends true ? Exclude<ioBroker.Adapter["oStates"], undefined> : undefined;
+}
+/** This type augments the ioBroker Adapter options to accept two generics for the objects and states cache */
+export declare type AdapterOptions<HasObjectsCache extends boolean | undefined = undefined, HasStatesCache extends boolean | undefined = undefined> = Omit<ioBroker.AdapterOptions, "objects" | "states"> & (true extends HasObjectsCache ? {
+    objects: true;
+} : {
+    objects?: HasObjectsCache;
+}) & (true extends HasStatesCache ? {
+    states: true;
+} : {
+    states?: HasStatesCache;
+});
+/** Selects the correct instance type depending on the constructor params */
 interface AdapterConstructor {
-    new (adapterName: string): ioBroker.Adapter;
-    new (adapterOptions: ioBroker.AdapterOptions): ioBroker.Adapter;
-    (adapterName: string): ioBroker.Adapter;
-    (adapterOptions: ioBroker.AdapterOptions): ioBroker.Adapter;
+    new <HasObjectsCache extends boolean | undefined = undefined, HasStatesCache extends boolean | undefined = undefined>(adapterOptions: AdapterOptions<HasObjectsCache, HasStatesCache> | string): AdapterInstance<HasObjectsCache, HasStatesCache>;
+    <HasObjectsCache extends boolean | undefined = undefined, HasStatesCache extends boolean | undefined = undefined>(adapterOptions: AdapterOptions<HasObjectsCache, HasStatesCache> | string): AdapterInstance<HasObjectsCache, HasStatesCache>;
 }
 /** Creates a new adapter instance */
 export declare const adapter: AdapterConstructor;

--- a/build/utils.js
+++ b/build/utils.js
@@ -1,4 +1,5 @@
 "use strict";
+/* eslint-disable @typescript-eslint/no-var-requires */
 Object.defineProperty(exports, "__esModule", { value: true });
 const fs = require("fs");
 const path = require("path");
@@ -46,7 +47,6 @@ function getConfig() {
 }
 exports.getConfig = getConfig;
 /** Creates a new adapter instance */
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 exports.adapter = require(path.join(exports.controllerDir, "lib/adapter.js"));
 /** Creates a new adapter instance */
 exports.Adapter = exports.adapter;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -59,10 +59,10 @@ export interface AdapterInstance<
 > extends Omit<ioBroker.Adapter, "oObjects" | "oStates"> {
 	oObjects: HasObjectsCache extends true
 		? Exclude<ioBroker.Adapter["oObjects"], undefined>
-		: never;
+		: undefined;
 	oStates: HasStatesCache extends true
 		? Exclude<ioBroker.Adapter["oStates"], undefined>
-		: never;
+		: undefined;
 }
 
 /** This type augments the ioBroker Adapter options to accept two generics for the objects and states cache */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+
 import * as fs from "fs";
 import * as path from "path";
 
@@ -48,14 +50,55 @@ export function getConfig(): Record<string, any> {
 	);
 }
 
-interface AdapterConstructor {
-	new (adapterName: string): ioBroker.Adapter;
-	new (adapterOptions: ioBroker.AdapterOptions): ioBroker.Adapter;
-	(adapterName: string): ioBroker.Adapter;
-	(adapterOptions: ioBroker.AdapterOptions): ioBroker.Adapter;
+/**
+ * This type is used to include and exclude the states and objects cache from the adaptert type definition depending on the creation options
+ */
+export interface AdapterInstance<
+	HasObjectsCache extends boolean | undefined = undefined,
+	HasStatesCache extends boolean | undefined = undefined
+> extends Omit<ioBroker.Adapter, "oObjects" | "oStates"> {
+	oObjects: HasObjectsCache extends true
+		? Exclude<ioBroker.Adapter["oObjects"], undefined>
+		: never;
+	oStates: HasStatesCache extends true
+		? Exclude<ioBroker.Adapter["oStates"], undefined>
+		: never;
 }
+
+/** This type augments the ioBroker Adapter options to accept two generics for the objects and states cache */
+export type AdapterOptions<
+	HasObjectsCache extends boolean | undefined = undefined,
+	HasStatesCache extends boolean | undefined = undefined
+> = Omit<ioBroker.AdapterOptions, "objects" | "states"> &
+	(true extends HasObjectsCache
+		? { objects: true }
+		: { objects?: HasObjectsCache }) &
+	(true extends HasStatesCache
+		? { states: true }
+		: { states?: HasStatesCache });
+
+/** Selects the correct instance type depending on the constructor params */
+interface AdapterConstructor {
+	new <
+		HasObjectsCache extends boolean | undefined = undefined,
+		HasStatesCache extends boolean | undefined = undefined
+	>(
+		adapterOptions:
+			| AdapterOptions<HasObjectsCache, HasStatesCache>
+			| string,
+	): AdapterInstance<HasObjectsCache, HasStatesCache>;
+
+	<
+		HasObjectsCache extends boolean | undefined = undefined,
+		HasStatesCache extends boolean | undefined = undefined
+	>(
+		adapterOptions:
+			| AdapterOptions<HasObjectsCache, HasStatesCache>
+			| string,
+	): AdapterInstance<HasObjectsCache, HasStatesCache>;
+}
+
 /** Creates a new adapter instance */
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 export const adapter: AdapterConstructor = require(path.join(
 	controllerDir,
 	"lib/adapter.js",

--- a/test/types/utils.ts
+++ b/test/types/utils.ts
@@ -23,3 +23,15 @@ class adapter9 extends utils.Adapter<false, true> {
 		super({ ...options, states: true });
 	}
 }
+
+class adapter10 extends utils.Adapter<true> {
+	constructor(options: utils.AdapterOptions) {
+		super({ ...options, objects: true });
+	}
+}
+
+class adapter11 extends utils.Adapter {
+	constructor(options: utils.AdapterOptions) {
+		super({ ...options });
+	}
+}

--- a/test/types/utils.ts
+++ b/test/types/utils.ts
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/explicit-member-accessibility */
+/* eslint-disable @typescript-eslint/class-name-casing */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import * as utils from "../../src/utils";
 
 const name = "foobar";
@@ -15,9 +18,8 @@ const adapter6 = utils.Adapter(options);
 const adapter7 = new utils.adapter(options);
 const adapter8 = new utils.Adapter({ ...options, objects: true });
 
-class adapter9 extends utils.Adapter {
-	constructor() {
-		super({ name: "foo", objects: true });
-		this.oObjects;
+class adapter9 extends utils.Adapter<false, true> {
+	constructor(options: utils.AdapterOptions) {
+		super({ ...options, states: true });
 	}
 }


### PR DESCRIPTION
This is another attempt for the conditional cache types. It now mainly works, with the small downside that the Adapter class needs generic parameters when using TypeScript. For example:
```ts
// class with only objects cache
class Adapter1 extends utils.Adapter<true> {
	constructor(options: utils.AdapterOptions) {
		super({ ...options, objects: true });
	}
}

// class with only states cache
class Adapter2 extends utils.Adapter<false, true> {
	constructor(options: utils.AdapterOptions) {
		super({ ...options, states: true });
	}
}

// class with states and objects cache
class Adapter3 extends utils.Adapter<true, true> {
	constructor(options: utils.AdapterOptions) {
		super({ ...options, objects: true, states: true });
	}
}
```