### PR TITLE
Expose `utils.EXIT_CODES`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ const instanceDataDir = utils.getAbsoluteInstanceDataDir(this);
 Returns the absolute path of the data directory for the current adapter instance.
 On linux, this is usually `/opt/iobroker/iobroker-data/<adapterName>.<instanceNr>`
 
+### `EXIT_CODES`
+
+```js
+adapter.terminate(
+	"for some reason",
+	utils.EXIT_CODES.ADAPTER_REQUESTED_TERMINATION,
+);
+```
+
+Use standardized exit codes if your adapter needs to terminate.
+
 ## Automatic backup of data files
 
 ioBroker has the ability to include files written by adapters in its backups. To enable that, you need to add the following to `io-package.json`:
@@ -74,6 +85,11 @@ This path is relative to the path returned by `getAbsoluteDefaultDataDir()`. The
 If you find errors in the definitions, e.g. function calls that should be allowed but aren't, please open an issue here or over at https://github.com/DefinitelyTyped/DefinitelyTyped and make sure to mention @AlCalzone.
 
 ## Changelog
+
+### v2.4.0 (2020-05-03)
+
+-   (AlCalzone) Updated core declarations to v3.0.6.
+-   (AlCalzone) Expose the predefined collection of adapter exit codes as `utils.EXIT_CODES`
 
 ### v2.3.1 (2020-04-17)
 

--- a/build/exitCodes.d.ts
+++ b/build/exitCodes.d.ts
@@ -1,15 +1,4 @@
-/// <reference types="iobroker" />
-export * from "./utils";
-/**
- * Returns the absolute path of the data directory for the current host. On linux, this is usually `/opt/iobroker/iobroker-data`.
- */
-export declare function getAbsoluteDefaultDataDir(): string;
-/**
- * Returns the absolute path of the data directory for the current adapter instance.
- * On linux, this is usually `/opt/iobroker/iobroker-data/<adapterName>.<instanceNr>`
- */
-export declare function getAbsoluteInstanceDataDir(adapterObject: ioBroker.Adapter): string;
-export declare const EXIT_CODES: Readonly<{
+export declare type ExitCodes = Readonly<{
     NO_ERROR: number;
     JS_CONTROLLER_STOPPED: number;
     INVALID_ADAPTER_CONFIG: number;

--- a/build/exitCodes.js
+++ b/build/exitCodes.js
@@ -1,0 +1,3 @@
+"use strict";
+/* eslint-disable @typescript-eslint/class-name-casing */
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/build/index.js
+++ b/build/index.js
@@ -26,4 +26,4 @@ function getAbsoluteInstanceDataDir(adapterObject) {
 }
 exports.getAbsoluteInstanceDataDir = getAbsoluteInstanceDataDir;
 // TODO: Expose some system utilities here, e.g. for installing npm modules (GH#1)
-exports.EXIT_CODES = Object.assign({}, require(path.join(utils.controllerDir, "lib/exitCodes")));
+exports.EXIT_CODES = Object.freeze(Object.assign({}, require(path.join(utils.controllerDir, "lib/exitCodes"))));

--- a/build/index.js
+++ b/build/index.js
@@ -1,13 +1,13 @@
 "use strict";
-/* eslint-disable @typescript-eslint/no-var-requires */
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
 }
 Object.defineProperty(exports, "__esModule", { value: true });
-// Export all methods that used to be in utils.js
-__export(require("./utils"));
 const path = require("path");
 const utils = require("./utils");
+/* eslint-disable @typescript-eslint/no-var-requires */
+// Export all methods that used to be in utils.js
+__export(require("./utils"));
 // Export some additional utility methods
 const controllerTools = require(path.join(utils.controllerDir, "lib/tools"));
 /**
@@ -26,3 +26,4 @@ function getAbsoluteInstanceDataDir(adapterObject) {
 }
 exports.getAbsoluteInstanceDataDir = getAbsoluteInstanceDataDir;
 // TODO: Expose some system utilities here, e.g. for installing npm modules (GH#1)
+exports.EXIT_CODES = Object.assign({}, require(path.join(utils.controllerDir, "lib/exitCodes")));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@iobroker/adapter-core",
-	"version": "2.3.1",
+	"version": "2.4.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iobroker/adapter-core",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Core module to be used in ioBroker adapters. Acts as the bridge to js-controller.",
   "author": {
     "name": "AlCalzone",
@@ -59,6 +59,6 @@
     "typescript": "^3.4.5"
   },
   "dependencies": {
-    "@types/iobroker": "^3.0.4"
+    "@types/iobroker": "^3.0.6"
   }
 }

--- a/src/exitCodes.ts
+++ b/src/exitCodes.ts
@@ -1,0 +1,43 @@
+/* eslint-disable @typescript-eslint/class-name-casing */
+
+// This was extracted from https://raw.githubusercontent.com/ioBroker/ioBroker.js-controller/master/lib/exitCodes.js
+// Keep this in sync when a new exit code is added
+
+export type ExitCodes = Readonly<{
+	NO_ERROR: number;
+	JS_CONTROLLER_STOPPED: number;
+	INVALID_ADAPTER_CONFIG: number;
+	NO_ADAPTER_CONFIG_FOUND: number;
+	INVALID_CONFIG_OBJECT: number;
+	INVALID_ADAPTER_ID: number;
+	UNCAUGHT_EXCEPTION: number;
+	ADAPTER_ALREADY_RUNNING: number;
+	INSTANCE_IS_DISABLED: number;
+	CANNOT_GZIP_DIRECTORY: number;
+	CANNOT_FIND_ADAPTER_DIR: number;
+	ADAPTER_REQUESTED_TERMINATION: number;
+	UNKNOWN_PACKET_NAME: number;
+	ADAPTER_REQUESTED_REBUILD: number;
+	CANNOT_READ_INSTANCES: number;
+	NO_MULTIPLE_INSTANCES_ALLOWED: number;
+	NO_MULTIPLE_INSTANCES_ALLOWED_ON_HOST: number;
+	NO_CONNECTION_TO_OBJ_DB: number;
+	NO_CONNECTION_TO_STATES_DB: number;
+	INSTANCE_ALREADY_EXISTS: number;
+	CANNOT_INSTALL_NPM_PACKET: number;
+	CANNOT_EXTRACT_FROM_ZIP: number;
+	INVALID_IO_PACKAGE_JSON: number;
+	CANNOT_COPY_DIR: number;
+	MISSING_ADAPTER_FILES: number;
+	INVALID_NPM_VERSION: number;
+	INVALID_NODE_VERSION: number;
+	INVALID_OS: number;
+	INVALID_DEPENDENCY_VERSION: number;
+	INVALID_ARGUMENTS: number;
+	INVALID_PASSWORD: number;
+	MISSING_CONFIG_JSON: number;
+	CANNOT_DELETE_NON_DELETABLE: number;
+	CANNOT_GET_STATES: number;
+	CANNOT_GET_REPO_LIST: number;
+	START_IMMEDIATELY_AFTER_STOP: number;
+}>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
+import * as path from "path";
+import { ExitCodes } from "./exitCodes";
+import * as utils from "./utils";
 /* eslint-disable @typescript-eslint/no-var-requires */
 
 // Export all methods that used to be in utils.js
 export * from "./utils";
-
-import * as path from "path";
-import * as utils from "./utils";
 
 // Export some additional utility methods
 
@@ -28,3 +28,8 @@ export function getAbsoluteInstanceDataDir(
 }
 
 // TODO: Expose some system utilities here, e.g. for installing npm modules (GH#1)
+
+export const EXIT_CODES = {
+	// Create a shallow copy so compact adapters cannot overwrite the dict in js-controller
+	...require(path.join(utils.controllerDir, "lib/exitCodes")),
+} as ExitCodes;

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export function getAbsoluteInstanceDataDir(
 
 // TODO: Expose some system utilities here, e.g. for installing npm modules (GH#1)
 
-export const EXIT_CODES = {
+export const EXIT_CODES = Object.freeze({
 	// Create a shallow copy so compact adapters cannot overwrite the dict in js-controller
 	...require(path.join(utils.controllerDir, "lib/exitCodes")),
-} as ExitCodes;
+}) as ExitCodes;

--- a/test/types/utils.ts
+++ b/test/types/utils.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/explicit-member-accessibility */
 /* eslint-disable @typescript-eslint/class-name-casing */
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import * as utils from "../../src/utils";
+import * as utils from "../../src/index";
 
 const name = "foobar";
 const options = { name };
@@ -35,3 +35,5 @@ class adapter11 extends utils.Adapter {
 		super({ ...options });
 	}
 }
+
+const code: number = utils.EXIT_CODES.ADAPTER_REQUESTED_TERMINATION;


### PR DESCRIPTION
Including auto-completion:
![grafik](https://user-images.githubusercontent.com/17641229/80913560-c8d6c680-8d45-11ea-965b-6ec2a6cb2311.png)

And the object is shallow-copied and frozen before exporting so compact adapters cannot overwrite const for other adapters:
![grafik](https://user-images.githubusercontent.com/17641229/80913538-9af18200-8d45-11ea-9ef9-a0a60c9ff926.png)
