### PR TITLE
Add fallback solution to detect js-controller if require.resolve fails

### DIFF
--- a/build/utils.js
+++ b/build/utils.js
@@ -1,5 +1,6 @@
 "use strict";
 /* eslint-disable @typescript-eslint/no-var-requires */
+var _a;
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Adapter = exports.adapter = exports.getConfig = exports.controllerDir = void 0;
 const fs = require("fs");
@@ -12,11 +13,13 @@ function getControllerDir(isInstall) {
     // Find the js-controller location
     const possibilities = ["iobroker.js-controller", "ioBroker.js-controller"];
     let controllerPath;
+    // First try to let Node.js resolve the package by itself
     for (const pkg of possibilities) {
         try {
             const possiblePath = require.resolve(pkg);
             if (fs.existsSync(possiblePath)) {
-                controllerPath = possiblePath;
+                // require.resolve returns the main file, we want the directory
+                controllerPath = path.dirname(possiblePath);
                 break;
             }
         }
@@ -24,8 +27,34 @@ function getControllerDir(isInstall) {
             /* not found */
         }
     }
+    // As a fallback solution, we walk up the directory tree until we reach the root or find js-controller
     // Apparently, checking vs null/undefined may miss the odd case of controllerPath being ""
     // Thus we check for falsyness, which includes failing on an empty path
+    if (!controllerPath) {
+        let curDir = path.join(__dirname, "../node_modules");
+        let parentDir;
+        outer: while (true) {
+            for (const pkg of possibilities) {
+                const possiblePath = path.join(curDir, pkg);
+                try {
+                    if (fs.existsSync(possiblePath)) {
+                        controllerPath = possiblePath;
+                        break outer;
+                    }
+                }
+                catch (_b) {
+                    // don't care
+                }
+            }
+            // Nothing found here, go up one level
+            parentDir = path.dirname(curDir);
+            if (parentDir === curDir) {
+                // we've reached the root without finding js-controller
+                break;
+            }
+            curDir = parentDir;
+        }
+    }
     if (!controllerPath) {
         if (!isInstall) {
             console.log("Cannot find js-controller");
@@ -36,12 +65,10 @@ function getControllerDir(isInstall) {
         }
     }
     // we found the controller
-    return path.dirname(controllerPath);
+    return controllerPath;
 }
 /** The root directory of JS-Controller */
-exports.controllerDir = getControllerDir(typeof process !== "undefined" &&
-    process.argv &&
-    process.argv.indexOf("--install") !== -1);
+exports.controllerDir = getControllerDir(!!((_a = process === null || process === void 0 ? void 0 : process.argv) === null || _a === void 0 ? void 0 : _a.includes("--install")));
 /** Reads the configuration file of JS-Controller */
 function getConfig() {
     return JSON.parse(fs.readFileSync(path.join(exports.controllerDir, "conf/iobroker.json"), "utf8"));


### PR DESCRIPTION
This is mainly for dev situations with symlinked adapter directories. Seems that require.resolve doesn't like this.

closes #333