### PR TITLE
js-controller v5 preparations

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ Currently, the following **methods** are available:
 -   `commonTools.pattern2RegEx` - Converts a pattern to match object IDs into a RegEx string that can be used in `new RegExp(...)`
 -   `commonTools.getAdapterDir` - Finds the adapter directory of a given adapter
 -   `commonTools.getInstalledInfo` - Get list of all installed adapters and controller version on this host
+- 	`commonTools.getLocalAddress` - Get the localhost (IPv6 or IPv4) address according to the ioBroker config
+- 	`commonTools.getListenAllAddress` - Get the "listen all" (IPv6 or IPv4) address according to the ioBroker config
+- 	`commonTools.isLocalAddress` - Check if given IPv4 or IPv6 ip address corresponds to localhost
+- 	`commonTools.isListenAllAddress` - Check if given IPv4 or IPv6 ip address corresponds to "listen all" address
+- 	`commonTools.ensureDNSOrder` - Ensure that DNS resolution is performed according to ioBroker config
 
 And the following **modules** are exposed:
 
@@ -80,7 +85,7 @@ And the following **modules** are exposed:
 
 ioBroker has the ability to include files written by adapters in its backups. To enable that, you need to add the following to `io-package.json`:
 
-```json
+```js
 {
 	// ...
 	"common": {
@@ -111,6 +116,7 @@ If you find errors in the definitions, e.g. function calls that should be allowe
 
 ### **WORK IN PROGRESS**
 -   (foxriver76) port from `@types/iobroker` to `@iobroker/types`
+-   (foxriver76) export dns resolution methods
 
 ### 2.6.8 (2023-03-24)
 -   (Apollon77) Expose more JS-Controller internals under the `commonTools` export

--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ If you find errors in the definitions, e.g. function calls that should be allowe
 	Placeholder for the next version (at the beginning of the line):
 	### **WORK IN PROGRESS**
 -->
+
+### **WORK IN PROGRESS**
+-   (foxriver76) port from `@types/iobroker` to `@iobroker/types`
+
 ### 2.6.8 (2023-03-24)
 -   (Apollon77) Expose more JS-Controller internals under the `commonTools` export
 

--- a/build/controllerTools.d.ts
+++ b/build/controllerTools.d.ts
@@ -57,11 +57,38 @@ declare function getInstalledInfo(hostJsControllerVersion?: string): GetInstalle
  * Checks if we are running inside a docker container
  */
 declare function isDocker(): boolean;
+/**
+ * Checks if given ip address is matching ipv4 or ipv6 localhost
+ * @param ip ipv4 or ipv6 address
+ */
+declare function isLocalAddress(ip: string): boolean;
+/**
+ * Checks if given ip address is matching ipv4 or ipv6 "listen all" address
+ * @param ip ipv4 or ipv6 address
+ */
+declare function isListenAllAddress(ip: string): boolean;
+/**
+ * Retrieve the localhost address according to the configured DNS resolution strategy
+ */
+declare function getLocalAddress(): '127.0.0.1' | '::1';
+/**
+ * Get the ip to listen to all addresses according to configured DNS resolution strategy
+ */
+declare function getListenAllAddress(): '0.0.0.0' | '::';
+/**
+ * Ensure that DNS is resolved according to ioBroker config
+ */
+declare function ensureDNSOrder(): void;
 export declare const commonTools: {
     pattern2RegEx: typeof pattern2RegEx;
     getAdapterDir: typeof getAdapterDir;
     getInstalledInfo: typeof getInstalledInfo;
     isDocker: typeof isDocker;
+    getLocalAddress: typeof getLocalAddress;
+    getListenAllAddress: typeof getListenAllAddress;
+    isLocalAddress: typeof isLocalAddress;
+    isListenAllAddress: typeof isListenAllAddress;
+    ensureDNSOrder: typeof ensureDNSOrder;
     password: any;
     letsEncrypt: any;
     session: any;

--- a/build/controllerTools.d.ts
+++ b/build/controllerTools.d.ts
@@ -2,7 +2,7 @@ export declare let controllerCommonModulesInternal: any;
 /** The collection of utility functions in JS-Controller, formerly `lib/tools.js` */
 export declare const controllerToolsInternal: any;
 /**
- * Resolve a module that is either exported by @iobroker/js-controller-common (new controllers) or located in in the controller's `lib` directory (old controllers).
+ * Resolve a module that is either exported by @iobroker/js-controller-common (new controllers) or located in the controller's `lib` directory (old controllers).
  * @param name - The filename of the module to resolve
  * @param exportName - The name under which the module may be exported. Defaults to `name`.
  */
@@ -70,15 +70,11 @@ declare function isListenAllAddress(ip: string): boolean;
 /**
  * Retrieve the localhost address according to the configured DNS resolution strategy
  */
-declare function getLocalAddress(): '127.0.0.1' | '::1';
+declare function getLocalAddress(): "127.0.0.1" | "::1";
 /**
  * Get the ip to listen to all addresses according to configured DNS resolution strategy
  */
-declare function getListenAllAddress(): '0.0.0.0' | '::';
-/**
- * Ensure that DNS is resolved according to ioBroker config
- */
-declare function ensureDNSOrder(): void;
+declare function getListenAllAddress(): "0.0.0.0" | "::";
 export declare const commonTools: {
     pattern2RegEx: typeof pattern2RegEx;
     getAdapterDir: typeof getAdapterDir;
@@ -88,7 +84,6 @@ export declare const commonTools: {
     getListenAllAddress: typeof getListenAllAddress;
     isLocalAddress: typeof isLocalAddress;
     isListenAllAddress: typeof isListenAllAddress;
-    ensureDNSOrder: typeof ensureDNSOrder;
     password: any;
     letsEncrypt: any;
     session: any;

--- a/build/controllerTools.js
+++ b/build/controllerTools.js
@@ -116,11 +116,48 @@ function getInstalledInfo(hostJsControllerVersion) {
 function isDocker() {
     return exports.controllerToolsInternal.isDocker();
 }
+/**
+ * Checks if given ip address is matching ipv4 or ipv6 localhost
+ * @param ip ipv4 or ipv6 address
+ */
+function isLocalAddress(ip) {
+    return exports.controllerToolsInternal.isLocalAddress(ip);
+}
+/**
+ * Checks if given ip address is matching ipv4 or ipv6 "listen all" address
+ * @param ip ipv4 or ipv6 address
+ */
+function isListenAllAddress(ip) {
+    return exports.controllerToolsInternal.isListenAllAddress(ip);
+}
+/**
+ * Retrieve the localhost address according to the configured DNS resolution strategy
+ */
+function getLocalAddress() {
+    return exports.controllerToolsInternal.getLocalAddress();
+}
+/**
+ * Get the ip to listen to all addresses according to configured DNS resolution strategy
+ */
+function getListenAllAddress() {
+    return exports.controllerToolsInternal.getListenAllAddress();
+}
+/**
+ * Ensure that DNS is resolved according to ioBroker config
+ */
+function ensureDNSOrder() {
+    return exports.controllerToolsInternal.ensureDNSOrder();
+}
 exports.commonTools = {
     pattern2RegEx,
     getAdapterDir,
     getInstalledInfo,
     isDocker,
+    getLocalAddress,
+    getListenAllAddress,
+    isLocalAddress,
+    isListenAllAddress,
+    ensureDNSOrder,
     // TODO: Add more methods from lib/tools.js as needed
     password: resolveNamedModule("password"),
     letsEncrypt: resolveNamedModule("letsencrypt"),

--- a/build/controllerTools.js
+++ b/build/controllerTools.js
@@ -49,7 +49,7 @@ function resolveControllerTools() {
 exports.controllerToolsInternal = resolveControllerTools();
 // Export a subset of the utilties in controllerTools
 /**
- * Resolve a module that is either exported by @iobroker/js-controller-common (new controllers) or located in in the controller's `lib` directory (old controllers).
+ * Resolve a module that is either exported by @iobroker/js-controller-common (new controllers) or located in the controller's `lib` directory (old controllers).
  * @param name - The filename of the module to resolve
  * @param exportName - The name under which the module may be exported. Defaults to `name`.
  */
@@ -142,12 +142,6 @@ function getLocalAddress() {
 function getListenAllAddress() {
     return exports.controllerToolsInternal.getListenAllAddress();
 }
-/**
- * Ensure that DNS is resolved according to ioBroker config
- */
-function ensureDNSOrder() {
-    return exports.controllerToolsInternal.ensureDNSOrder();
-}
 exports.commonTools = {
     pattern2RegEx,
     getAdapterDir,
@@ -157,7 +151,6 @@ exports.commonTools = {
     getListenAllAddress,
     isLocalAddress,
     isListenAllAddress,
-    ensureDNSOrder,
     // TODO: Add more methods from lib/tools.js as needed
     password: resolveNamedModule("password"),
     letsEncrypt: resolveNamedModule("letsencrypt"),

--- a/build/index.d.ts
+++ b/build/index.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="iobroker" />
 import { ExitCodes } from "./exitCodes";
 export { commonTools } from "./controllerTools";
 export * from "./utils";

--- a/build/utils.d.ts
+++ b/build/utils.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="iobroker" />
 /** The root directory of JS-Controller */
 export declare const controllerDir: string;
 /** Reads the configuration file of JS-Controller */

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.6.8",
       "license": "MIT",
       "dependencies": {
-        "@types/iobroker": "^4.0.5"
+        "@types/iobroker": "npm:@iobroker/types@^5.0.1-alpha.0-20230415-c507341d"
       },
       "devDependencies": {
         "@alcalzone/release-script": "~3.5.9",
@@ -454,11 +454,12 @@
       "dev": true
     },
     "node_modules/@types/iobroker": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/iobroker/-/iobroker-4.0.5.tgz",
-      "integrity": "sha512-D1tJwuDQEQQQ/cZVFjFjFUhUuMxJbfrz5U2UooiZwhgs69D/t8IowMvBI6Lk4ZR8HnCSxYwWHVRKyQnEMNgJPA==",
-      "dependencies": {
-        "@types/node": "*"
+      "name": "@iobroker/types",
+      "version": "5.0.1-alpha.0-20230415-c507341d",
+      "resolved": "https://registry.npmjs.org/@iobroker/types/-/types-5.0.1-alpha.0-20230415-c507341d.tgz",
+      "integrity": "sha512-G5RxkbgrDhrzzWy8aop7YXdh/g23jqrvyQHOJ5a6aJcEPbApd/6tta97aMT5jVpCjeE8NhVDweoboOD20U4GkQ==",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@types/json-schema": {
@@ -476,7 +477,8 @@
     "node_modules/@types/node": {
       "version": "18.15.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.7.tgz",
-      "integrity": "sha512-LFmUbFunqmBn26wJZgZPYZPrDR1RwGOu2v79Mgcka1ndO6V0/cwjivPTc4yoK6n9kmw4/ls1r8cLrvh2iMibFA=="
+      "integrity": "sha512-LFmUbFunqmBn26wJZgZPYZPrDR1RwGOu2v79Mgcka1ndO6V0/cwjivPTc4yoK6n9kmw4/ls1r8cLrvh2iMibFA==",
+      "dev": true
     },
     "node_modules/@types/proxyquire": {
       "version": "1.3.28",
@@ -750,12 +752,12 @@
       }
     },
     "node_modules/alcalzone-shared": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/alcalzone-shared/-/alcalzone-shared-4.0.1.tgz",
-      "integrity": "sha512-6t0LFCIGvBG24grbV93Y1+MJjoyqgUpPOp/PkOcal1ZXXUUMEaZKPu6NfN6e3x5k2P2mnNaY2eXn/VmpWDLzYA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/alcalzone-shared/-/alcalzone-shared-4.0.8.tgz",
+      "integrity": "sha512-Rr0efCjNL9lw7miDvU8exL87Y42ehsLU2jUGNQUphhnlvxnTMrHeApWgoOSGZvsE2PhxC3KO7Z+VpQ/IbuV3aA==",
       "dev": true,
       "dependencies": {
-        "debug": "^4.3.2"
+        "debug": "^4.3.4"
       },
       "engines": {
         "node": ">=12"
@@ -3650,12 +3652,9 @@
       "dev": true
     },
     "@types/iobroker": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/iobroker/-/iobroker-4.0.5.tgz",
-      "integrity": "sha512-D1tJwuDQEQQQ/cZVFjFjFUhUuMxJbfrz5U2UooiZwhgs69D/t8IowMvBI6Lk4ZR8HnCSxYwWHVRKyQnEMNgJPA==",
-      "requires": {
-        "@types/node": "*"
-      }
+      "version": "npm:@iobroker/types@5.0.1-alpha.0-20230415-c507341d",
+      "resolved": "https://registry.npmjs.org/@iobroker/types/-/types-5.0.1-alpha.0-20230415-c507341d.tgz",
+      "integrity": "sha512-G5RxkbgrDhrzzWy8aop7YXdh/g23jqrvyQHOJ5a6aJcEPbApd/6tta97aMT5jVpCjeE8NhVDweoboOD20U4GkQ=="
     },
     "@types/json-schema": {
       "version": "7.0.11",
@@ -3672,7 +3671,8 @@
     "@types/node": {
       "version": "18.15.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.7.tgz",
-      "integrity": "sha512-LFmUbFunqmBn26wJZgZPYZPrDR1RwGOu2v79Mgcka1ndO6V0/cwjivPTc4yoK6n9kmw4/ls1r8cLrvh2iMibFA=="
+      "integrity": "sha512-LFmUbFunqmBn26wJZgZPYZPrDR1RwGOu2v79Mgcka1ndO6V0/cwjivPTc4yoK6n9kmw4/ls1r8cLrvh2iMibFA==",
+      "dev": true
     },
     "@types/proxyquire": {
       "version": "1.3.28",
@@ -3842,12 +3842,12 @@
       }
     },
     "alcalzone-shared": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/alcalzone-shared/-/alcalzone-shared-4.0.1.tgz",
-      "integrity": "sha512-6t0LFCIGvBG24grbV93Y1+MJjoyqgUpPOp/PkOcal1ZXXUUMEaZKPu6NfN6e3x5k2P2mnNaY2eXn/VmpWDLzYA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/alcalzone-shared/-/alcalzone-shared-4.0.8.tgz",
+      "integrity": "sha512-Rr0efCjNL9lw7miDvU8exL87Y42ehsLU2jUGNQUphhnlvxnTMrHeApWgoOSGZvsE2PhxC3KO7Z+VpQ/IbuV3aA==",
       "dev": true,
       "requires": {
-        "debug": "^4.3.2"
+        "debug": "^4.3.4"
       }
     },
     "ansi-colors": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,6 @@
     "typescript": "^4.9.5"
   },
   "dependencies": {
-    "@types/iobroker": "^4.0.5"
+    "@types/iobroker": "npm:@iobroker/types@^5.0.1-alpha.0-20230415-c507341d"
   }
 }

--- a/src/controllerTools.ts
+++ b/src/controllerTools.ts
@@ -1,6 +1,7 @@
 import * as path from "path";
 import { tryResolvePackage } from "./helpers";
 import * as utils from "./utils";
+import {setDefaultResultOrder} from "dns";
 /* eslint-disable @typescript-eslint/no-var-requires */
 
 export let controllerCommonModulesInternal: any;
@@ -160,11 +161,54 @@ function isDocker(): boolean {
 	return controllerToolsInternal.isDocker();
 }
 
+/**
+ * Checks if given ip address is matching ipv4 or ipv6 localhost
+ * @param ip ipv4 or ipv6 address
+ */
+function isLocalAddress(ip: string): boolean {
+	return controllerToolsInternal.isLocalAddress(ip)
+}
+
+/**
+ * Checks if given ip address is matching ipv4 or ipv6 "listen all" address
+ * @param ip ipv4 or ipv6 address
+ */
+function isListenAllAddress(ip: string): boolean {
+	return controllerToolsInternal.isListenAllAddress(ip)
+}
+
+/**
+ * Retrieve the localhost address according to the configured DNS resolution strategy
+ */
+function getLocalAddress(): '127.0.0.1' | '::1' {
+	return controllerToolsInternal.getLocalAddress()
+}
+
+/**
+ * Get the ip to listen to all addresses according to configured DNS resolution strategy
+ */
+function getListenAllAddress(): '0.0.0.0' | '::' {
+	return controllerToolsInternal.getListenAllAddress()
+
+}
+
+/**
+ * Ensure that DNS is resolved according to ioBroker config
+ */
+function ensureDNSOrder(): void {
+	return controllerToolsInternal.ensureDNSOrder()
+}
+
 export const commonTools = {
 	pattern2RegEx,
 	getAdapterDir,
 	getInstalledInfo,
 	isDocker,
+	getLocalAddress,
+	getListenAllAddress,
+	isLocalAddress,
+	isListenAllAddress,
+	ensureDNSOrder,
 	// TODO: Add more methods from lib/tools.js as needed
 
 	password: resolveNamedModule("password"),
@@ -173,3 +217,4 @@ export const commonTools = {
 	zipFiles: resolveNamedModule("zipFiles"),
 	// TODO: expose more (internal) controller modules as needed
 };
+

--- a/src/controllerTools.ts
+++ b/src/controllerTools.ts
@@ -1,7 +1,6 @@
 import * as path from "path";
 import { tryResolvePackage } from "./helpers";
 import * as utils from "./utils";
-import {setDefaultResultOrder} from "dns";
 /* eslint-disable @typescript-eslint/no-var-requires */
 
 export let controllerCommonModulesInternal: any;
@@ -54,7 +53,7 @@ export const controllerToolsInternal = resolveControllerTools();
 // Export a subset of the utilties in controllerTools
 
 /**
- * Resolve a module that is either exported by @iobroker/js-controller-common (new controllers) or located in in the controller's `lib` directory (old controllers).
+ * Resolve a module that is either exported by @iobroker/js-controller-common (new controllers) or located in the controller's `lib` directory (old controllers).
  * @param name - The filename of the module to resolve
  * @param exportName - The name under which the module may be exported. Defaults to `name`.
  */
@@ -166,7 +165,7 @@ function isDocker(): boolean {
  * @param ip ipv4 or ipv6 address
  */
 function isLocalAddress(ip: string): boolean {
-	return controllerToolsInternal.isLocalAddress(ip)
+	return controllerToolsInternal.isLocalAddress(ip);
 }
 
 /**
@@ -174,29 +173,21 @@ function isLocalAddress(ip: string): boolean {
  * @param ip ipv4 or ipv6 address
  */
 function isListenAllAddress(ip: string): boolean {
-	return controllerToolsInternal.isListenAllAddress(ip)
+	return controllerToolsInternal.isListenAllAddress(ip);
 }
 
 /**
  * Retrieve the localhost address according to the configured DNS resolution strategy
  */
-function getLocalAddress(): '127.0.0.1' | '::1' {
-	return controllerToolsInternal.getLocalAddress()
+function getLocalAddress(): "127.0.0.1" | "::1" {
+	return controllerToolsInternal.getLocalAddress();
 }
 
 /**
  * Get the ip to listen to all addresses according to configured DNS resolution strategy
  */
-function getListenAllAddress(): '0.0.0.0' | '::' {
-	return controllerToolsInternal.getListenAllAddress()
-
-}
-
-/**
- * Ensure that DNS is resolved according to ioBroker config
- */
-function ensureDNSOrder(): void {
-	return controllerToolsInternal.ensureDNSOrder()
+function getListenAllAddress(): "0.0.0.0" | "::" {
+	return controllerToolsInternal.getListenAllAddress();
 }
 
 export const commonTools = {
@@ -208,7 +199,6 @@ export const commonTools = {
 	getListenAllAddress,
 	isLocalAddress,
 	isListenAllAddress,
-	ensureDNSOrder,
 	// TODO: Add more methods from lib/tools.js as needed
 
 	password: resolveNamedModule("password"),
@@ -217,4 +207,3 @@ export const commonTools = {
 	zipFiles: resolveNamedModule("zipFiles"),
 	// TODO: expose more (internal) controller modules as needed
 };
-


### PR DESCRIPTION
- port from  @types/iobroker to @iobroker/types
- added DNS resolution tools emthods

we should wait until it is out of alpha maybe or start already? And then the more important question is, always install newest types or limit it to `minor` updates?