### PR TITLE
Update README.md (i18n docu)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ console.log(I18n.translate('text to translate %s', 'argument1'));
 console.log(JSON.stringify(I18n.getTranslatedObject('text to translate %s and %s', 'argument1', 'argument2')));
 ```
 
-You can place your `i18n` folder in root of adapter or in `lib` folder. If your `i18n` directory containing the `i18n` files is in `lib` directory, call the `init` function like this:
+You can place your `i18n` folder in root of adapter or in `lib` folder. If your `i18n` folder containing the `i18n` files is in `lib` directory, call the `init` function like this:
 
 ```javascript
 const { join } = require('node:path');

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ console.log(I18n.translate('text to translate %s', 'argument1'));
 console.log(JSON.stringify(I18n.getTranslatedObject('text to translate %s and %s', 'argument1', 'argument2')));
 ```
 
-You can place your `i18n` folder in root of adapter or in `lib` folder. If your `i18n` folder containing the `i18n` files is in `lib` directory, call the `init` function like this:
+You can place your `i18n` folder in root of adapter or in `lib` folder. If your `i18n` folder containing the internationalisation files is in `lib` directory, call the `init` function like this:
 
 ```javascript
 const { join } = require('node:path');

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ console.log(I18n.translate('text to translate %s', 'argument1'));
 console.log(JSON.stringify(I18n.getTranslatedObject('text to translate %s and %s', 'argument1', 'argument2')));
 ```
 
-You can place your `i18n` folder in root of adapter or in `lib` folder. If your `i18n` files are in `lib` directory, so call the `init` function like this:
+You can place your `i18n` folder in root of adapter or in `lib` folder. If your `i18n` directory containing the `i18n` files is in `lib` directory, call the `init` function like this:
 
 ```javascript
 const { join } = require('node:path');


### PR DESCRIPTION
i18n data files should always be located within an i18n directory. This directory might be located at root of adapter or i.e. within /lib or any other directory.

Adapt README to make this more clearly.

@GermanBluefox 
Please review / confirm or reject